### PR TITLE
add mercurial to list of build tools to install

### DIFF
--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -25,6 +25,7 @@ yum -y install \
 	sclo-vagrant1-vagrant \
 	sclo-vagrant1-vagrant-libvirt \
 	git \
+	mercurial \
 	gcc \
 	make \
 	python-py \


### PR DESCRIPTION
On Heketi PR #1068 the centos-ci run failed because glide couldn't
fetch a (new) dependency package because mercurial (hg) was not
available. Add this commit message author's favorite dcvs to the
packages to install via yum.
Note that this was already working on travis so centos-ci
was the only environment lacking hg.

Signed-off-by: John Mulligan <jmulligan@redhat.com>