### PR TITLE
Add bootstrap.sh to launch the test in the CentOS CI

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+EXEC_BIN="$(basename $1)"
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$1" "root@$(cat $WORKSPACE/hosts):$EXEC_BIN"
+if [ -z $2 ];
+then
+    ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@$(cat $WORKSPACE/hosts)" "./$EXEC_BIN"
+else
+    ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@$(cat $WORKSPACE/hosts)" "$2" "./$EXEC_BIN"
+fi


### PR DESCRIPTION
The `bootstrap.sh` script comes from gluster/centosci:scripts/common/
and is used to start a shell script as a test on the reserved machine
that is provided by the CentOS CI.

This script is used by the rewrite of the Jenkins Job from XML format to
a Jenkins Job Builder .yml file. It will be easier to update the
configuration this way, and provides for more re-use of standard
scripts.

Signed-off-by: Niels de Vos <ndevos@redhat.com>