### PR TITLE
README: correct the URL to the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # heketi centos-ci tests
 
 This branch contains the helper scripts for the heketi job of the centos-ci.
-They are integrated into the centos-ci by 
-https://github.com/gluster/glusterfs-patch-acceptance-tests/tree/master/centos-ci/heketi-functional .
+They are integrated into the centos-ci with the configuration at https://github.com/gluster/centosci/blob/master/heketi-functional.yml .


### PR DESCRIPTION
The older configuration (XML based) has been moved to Jenkins Job
Builder format (yaml) in a new repository.