### PR TITLE
Install vagrant from Vagrant website instead of SCL

### DIFF
--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -33,7 +33,11 @@ yum -y install \
 	make \
 	python-py \
 	python-virtualenv \
-	ansible
+	ansible \
+	libvirt \
+	libvirt-devel
+
+yum -y group install "Development Tools"
 
 if ! rpm -q vagrant
 then

--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -27,8 +27,6 @@ yum -y install \
 	qemu-kvm \
 	qemu-kvm-tools \
 	qemu-img \
-	sclo-vagrant1-vagrant \
-	sclo-vagrant1-vagrant-libvirt \
 	git \
 	mercurial \
 	gcc \
@@ -36,6 +34,12 @@ yum -y install \
 	python-py \
 	python-virtualenv \
 	ansible
+
+if ! rpm -q vagrant
+then
+       yum install -y https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.rpm
+fi
+vagrant plugin install vagrant-libvirt
 
 # install Go (Heketi depends on version 1.6+)
 if ! yum -y install 'golang >= 1.6'

--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -6,6 +6,11 @@ set -e
 # TODO: disable debugging
 set -x
 
+vagrant_env(){
+ #scl enable sclo-vagrant1 -- "$@"
+ "$@"
+}
+
 # enable additional sources for yum
 # (SCL repository for Vagrant, epel for ansible)
 yum -y install centos-release-scl epel-release
@@ -105,7 +110,7 @@ git grep -q ^_sudo tests/functional/lib.sh || ( curl https://github.com/heketi/h
 # in order to get proper version metadata & caching support
 # (the echo is becuase of "set -e" and that an existing box will cause
 #  vagrant to return non-zero)
-scl enable sclo-vagrant1 -- \
+vagrant_env \
 	vagrant box add "https://vagrantcloud.com/centos/7" --provider "libvirt" \
 	|| echo "Warning: the vagrant box may already exist OR an error occured"
 
@@ -123,11 +128,11 @@ TEST_TARGET="test-functional"
 RC=0
 make -q "${TEST_TARGET}" > /dev/null 2>&1 || RC=$?
 if [[ ${RC} -eq 1 ]]; then
-	echo make "${TEST_TARGET}" | scl enable sclo-vagrant1 bash
+	echo make "${TEST_TARGET}" | vagrant_env bash
 else
 	# fallback for old branches that did not
 	# have the "test-functional target yet
 	cd $GOPATH/src/github.com/heketi/heketi/tests/functional
-	scl enable sclo-vagrant1 ./run.sh
+	vagrant_env ./run.sh
 fi
 


### PR DESCRIPTION
We have been using vagrant and vagrant-libvirt packages from CentOS SCL but we have an installation error now because of dependency issues.

While the SCL fixes the issues, we can use vagrant from the vagrant website. 

