### PR TITLE
Fix centos CI failure "nokogiri requires Ruby version < 3.1.dev, >= 2.5."

### DIFF
--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -39,7 +39,9 @@ yum -y install \
 	python-virtualenv \
 	ansible \
 	libvirt \
-	libvirt-devel
+	libvirt-devel \
+	ruby \
+	ruby-devel
 
 yum -y group install "Development Tools"
 
@@ -48,7 +50,7 @@ rpm -qa
 
 if ! rpm -q vagrant
 then
-       yum install -y https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.rpm
+       yum install -y https://releases.hashicorp.com/vagrant/2.2.14/vagrant_2.2.14_x86_64.rpm
 fi
 vagrant plugin install vagrant-libvirt
 

--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -11,6 +11,10 @@ vagrant_env(){
  "$@"
 }
 
+# get os debug info
+uname -a
+cat /etc/redhat-release
+
 # enable additional sources for yum
 # (SCL repository for Vagrant, epel for ansible)
 yum -y install centos-release-scl epel-release
@@ -38,6 +42,9 @@ yum -y install \
 	libvirt-devel
 
 yum -y group install "Development Tools"
+
+# list all rpms
+rpm -qa
 
 if ! rpm -q vagrant
 then
@@ -78,7 +85,7 @@ then
 	cd heketi
 	git fetch origin pull/${ghprbPullId}/head:pr_${ghprbPullId}
 	git checkout pr_${ghprbPullId}
-	
+
 	# Now rebase on top of master
 	git rebase master
 	if [ $? -ne 0 ] ; then


### PR DESCRIPTION
As part of this fix, We are upgrading vagrant and installing ruby, ruby-devel which is not part of `Development Tools` anymore.
Additionally, Added some debug commands for debug purposes.

Thanks, @raghavendra-talur for helping me with this
cc @phlogistonjohn 