### PR TITLE
drop support for ancient, irrelevant, build dependency tools

### DIFF
--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -79,7 +79,9 @@ fi
 # Before that we used godeps
 # (https://github.com/heketi/heketi/pull/400).
 # Originally, it was glock.
-# Detect here which one to use:
+#
+# Support for ancient build dependency tools dropped. Probe for glide
+# or not.
 cd heketi
 if [ -e glide.yaml ]
 then
@@ -87,12 +89,6 @@ then
 	then
 		curl https://glide.sh/get | sh
 	fi
-elif [ -e GLOCKFILE ]
-then
-	go get github.com/robfig/glock
-	glock sync github.com/heketi/heketi
-else
-	go get github.com/tools/godep
 fi
 
 # need to prevent sudo from disabling the SCL


### PR DESCRIPTION
The last 4-5 years glide has been the one and only dependency tool. Building versions of heketi older than that is not a job for this ci now.

This also clears the way for experimenting with non-glide dependency management with go modules.

Signed-off-by: John Mulligan <jmulligan@redhat.com>