### PR TITLE
Test with a recent version of go

### DIFF
--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -54,13 +54,14 @@ then
 fi
 vagrant plugin install vagrant-libvirt
 
-# install Go (Heketi depends on version 1.6+)
-if ! yum -y install 'golang >= 1.6'
+# install Go
+wantgover=1.15.14
+if ! yum -y install "golang >= ${wantgover}"
 then
 	# not the right version, install manually
 	# download URL comes from https://golang.org/dl/
-	curl -O https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
-	tar xzf go1.6.2.linux-amd64.tar.gz -C /usr/local
+	curl -O https://storage.googleapis.com/golang/go${wantgover}.linux-amd64.tar.gz
+	tar xzf go${wantgover}.linux-amd64.tar.gz -C /usr/local
 	export PATH=$PATH:/usr/local/go/bin
 fi
 

--- a/heketi-centos-ci-tests.sh
+++ b/heketi-centos-ci-tests.sh
@@ -54,17 +54,6 @@ then
 fi
 vagrant plugin install vagrant-libvirt
 
-# install Go
-wantgover=1.15.14
-if ! yum -y install "golang >= ${wantgover}"
-then
-	# not the right version, install manually
-	# download URL comes from https://golang.org/dl/
-	curl -O https://storage.googleapis.com/golang/go${wantgover}.linux-amd64.tar.gz
-	tar xzf go${wantgover}.linux-amd64.tar.gz -C /usr/local
-	export PATH=$PATH:/usr/local/go/bin
-fi
-
 # Vagrant needs libvirtd running
 systemctl start libvirtd
 systemctl start docker
@@ -96,6 +85,21 @@ then
 	    exit 1
 	fi
 	cd ..
+fi
+
+wantgover=1.15.14
+if [ -e "./heketi/tests/functional/test.env" ]; then
+    . "./heketi/tests/functional/test.env"
+fi
+
+# install Go
+if ! yum -y install "golang >= ${wantgover}"
+then
+	# not the right version, install manually
+	# download URL comes from https://golang.org/dl/
+	curl -O https://storage.googleapis.com/golang/go${wantgover}.linux-amd64.tar.gz
+	tar xzf go${wantgover}.linux-amd64.tar.gz -C /usr/local
+	export PATH=$PATH:/usr/local/go/bin
 fi
 
 # The latest way of doing dependencies is to use glide


### PR DESCRIPTION
First off, go 1.15.5 is old and has had many cves fixed.

Also, the build is failing due to how go invokes git. I think this may be fixed in more recent versions of go (and git).